### PR TITLE
feat(io): keep filter for region and runtime selection active

### DIFF
--- a/internal/io/input.go
+++ b/internal/io/input.go
@@ -19,7 +19,7 @@ func GetCheckboxes(label string, opts []string) ([]string, bool) {
 			Options:  opts,
 			PageSize: CheckboxesPageSize,
 		}
-		survey.AskOne(prompt, &checkboxes)
+		survey.AskOne(prompt, &checkboxes, survey.WithKeepFilter(true))
 
 		if len(checkboxes) == 0 {
 			Logger.Warn().Msg("Select values!")


### PR DESCRIPTION
Until now, if we entered a filter word on the selection screen and then selected any choice, the word we entered was cleared and all items were displayed again. With this change, the filter word will persist.

```
? Select regions you want to search.
 eu-west  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
  [x]  eu-west-1
> [x]  eu-west-2
  [ ]  eu-west-3
```