### PR TITLE
docs: add mise to install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Also this tool can support output results **as a CSV file.**
   aqua g -i go-to-k/lamver
   ```
 
+- mise
+
+  ```bash
+  mise use -g aqua:go-to-k/lamver
+  ```
+
 - Binary
   - [Releases](https://github.com/go-to-k/lamver/releases)
 - Git Clone and install(for developers)


### PR DESCRIPTION
## Summary
- Add mise (with aqua backend) to the Install section of the README

## Test plan
- [ ] `mise use -g aqua:go-to-k/lamver` resolves and installs the latest release