### PR TITLE
ci: fix branch filter to match branches with slashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     tags-ignore:
       - 'v[0-9]+.[0-9]+.[0-9]+'
     branches:
-      - '*'
+      - '**'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

The `'*'` glob in GitHub Actions does not match the `/` character, so feature branches like `feat/foo` never triggered `ci.yml` and CI was silently skipped on every feature-branch push. Switch to `'**'` so all branches run CI on push.

## Test plan

- [ ] CI runs on this feature branch
